### PR TITLE
Use BrokerAwareExtension instead

### DIFF
--- a/src/PHPStan/Reflection/PreciousPropertiesClassReflectionExtension.php
+++ b/src/PHPStan/Reflection/PreciousPropertiesClassReflectionExtension.php
@@ -3,13 +3,13 @@
 namespace Precious\PHPStan\Reflection;
 
 use PHPStan\Broker\Broker;
-use PHPStan\Reflection\BrokerAwareClassReflectionExtension;
+use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
 use Precious\Precious;
 
-class PreciousPropertiesClassReflectionExtension implements PropertiesClassReflectionExtension, BrokerAwareClassReflectionExtension
+class PreciousPropertiesClassReflectionExtension implements PropertiesClassReflectionExtension, BrokerAwareExtension
 {
     /** @var Broker */
     private $broker;


### PR DESCRIPTION
According to https://github.com/phpstan/phpstan/commit/95afaeecf8ed92f071ae888fe7c0c7812d480b79 the interface name was renamed a couple of years ago. The deprecated interface was removed from newer version of PHPStan thus causing failure in our projects